### PR TITLE
Add DeepL translation option

### DIFF
--- a/src/main/java/extension/translator.fxml
+++ b/src/main/java/extension/translator.fxml
@@ -52,12 +52,13 @@
           <content>
               <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
                <children>
-                  <RadioButton fx:id="rdArgos" layoutX="23.0" layoutY="25.0" mnemonicParsing="false" selected="true" text="Argos Open Tech">
-                     <toggleGroup>
-                        <ToggleGroup fx:id="tglAPI" />
-                     </toggleGroup></RadioButton>
-                  <RadioButton fx:id="rdMicrosoft" layoutX="23.0" layoutY="57.0" mnemonicParsing="false" text="Microsoft Translator" toggleGroup="$tglAPI" />
-                  <Pane fx:id="apiMicrosoftInfo" disable="true" layoutX="42.0" layoutY="84.0" prefHeight="72.0" prefWidth="228.0">
+                <RadioButton fx:id="rdArgos" layoutX="23.0" layoutY="25.0" mnemonicParsing="false" selected="true" text="Argos Open Tech">
+                   <toggleGroup>
+                      <ToggleGroup fx:id="tglAPI" />
+                   </toggleGroup></RadioButton>
+                <RadioButton fx:id="rdMicrosoft" layoutX="23.0" layoutY="57.0" mnemonicParsing="false" text="Microsoft Translator" toggleGroup="$tglAPI" />
+                <RadioButton fx:id="rdDeepl" layoutX="23.0" layoutY="89.0" mnemonicParsing="false" text="DeepL" toggleGroup="$tglAPI" />
+                <Pane fx:id="apiMicrosoftInfo" disable="true" layoutX="42.0" layoutY="116.0" prefHeight="72.0" prefWidth="228.0">
                      <children>
                         <TextField fx:id="apiMicrosoftKey" layoutX="61.0" layoutY="6.0" />
                         <Label layoutX="10.0" layoutY="10.0" text="API key:" />
@@ -65,8 +66,16 @@
                         <Label layoutX="10.0" layoutY="44.0" text="Region:" />
                      </children>
                   </Pane>
-                  <Label layoutX="170.0" layoutY="57.0" text="-&gt; 2M free characters per month, fast" textFill="#000000ad" />
-                  <Label layoutX="170.0" layoutY="25.0" text="-&gt; Doesn't have Finnish &amp; Dutch, free but slow" textFill="#000000ad" />
+                <Pane fx:id="apiDeeplInfo" disable="true" layoutX="42.0" layoutY="116.0" prefHeight="40.0" prefWidth="228.0">
+                   <children>
+                      <TextField fx:id="apiDeeplKey" layoutX="61.0" layoutY="6.0" />
+                      <Label layoutX="10.0" layoutY="10.0" text="API key:" />
+                   </children>
+                </Pane>
+                <Label layoutX="170.0" layoutY="57.0" text="-&gt; 2M free characters per month, fast" textFill="#000000ad" />
+                <Label layoutX="170.0" layoutY="25.0" text="-&gt; Doesn't have Finnish &amp; Dutch, free but slow" textFill="#000000ad" />
+                <Label layoutX="170.0" layoutY="89.0" text="-&gt; Need API key" textFill="#000000ad" />
+                <Label fx:id="apiError" layoutX="42.0" layoutY="164.0" textFill="red" />
                </children></AnchorPane>
           </content>
       </Tab>

--- a/src/main/java/translation/TranslatorFactory.java
+++ b/src/main/java/translation/TranslatorFactory.java
@@ -3,6 +3,7 @@ package translation;
 import extension.TranslatorExtension;
 import translation.translators.ArgosOpenTechTranslator;
 import translation.translators.MicrosoftTranslator;
+import translation.translators.DeeplTranslator;
 
 public class TranslatorFactory {
 
@@ -11,6 +12,9 @@ public class TranslatorFactory {
 
         if (api.equals("microsoft")) {
             return new MicrosoftTranslator(t.getMicrosoftKey(), t.getMicrosoftRegion());
+        }
+        else if (api.equals("deepl")) {
+            return new DeeplTranslator(t.getDeeplKey());
         }
         else {
             return new ArgosOpenTechTranslator();

--- a/src/main/java/translation/translators/DeeplTranslator.java
+++ b/src/main/java/translation/translators/DeeplTranslator.java
@@ -1,0 +1,85 @@
+package translation.translators;
+
+import com.squareup.okhttp.*;
+import extension.Language;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import translation.TranslationException;
+import translation.Translator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Simple DeepL API translator using OkHttp.
+ */
+public class DeeplTranslator extends Translator {
+
+    private final String apiKey;
+
+    public DeeplTranslator(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    protected String translate(String text, Language source, Language target) throws TranslationException {
+        return translate(Collections.singletonList(text), source, target).get(0);
+    }
+
+    @Override
+    protected List<String> translate(List<String> texts, Language source, Language target) throws TranslationException {
+        HttpUrl url = new HttpUrl.Builder()
+                .scheme("https")
+                .host("api-free.deepl.com")
+                .addPathSegment("v2")
+                .addPathSegment("translate")
+                .build();
+
+        FormEncodingBuilder formBuilder = new FormEncodingBuilder();
+        formBuilder.add("auth_key", apiKey);
+        formBuilder.add("target_lang", target.getLangCode().toUpperCase());
+        if (source != null) {
+            formBuilder.add("source_lang", source.getLangCode().toUpperCase());
+        }
+        for (String s : texts) {
+            formBuilder.add("text", s);
+        }
+
+        RequestBody body = formBuilder.build();
+        Request request = new Request.Builder().url(url).post(body).build();
+        OkHttpClient client = new OkHttpClient();
+
+        Response response;
+        try {
+            response = client.newCall(request).execute();
+        } catch (IOException e) {
+            throw new TranslationException("Something went wrong..");
+        }
+
+        if (response.code() == 403 || response.code() == 456) {
+            throw new TranslationException("Invalid DeepL API key");
+        }
+        if (response.code() != 200) {
+            throw new TranslationException("Translation failed with code: " + response.code());
+        }
+
+        try {
+            String result = response.body().string();
+            JSONArray arr = new JSONObject(result).getJSONArray("translations");
+            List<String> res = new ArrayList<>();
+            for (int i = 0; i < arr.length(); i++) {
+                res.add(arr.getJSONObject(i).getString("text"));
+            }
+            return res;
+        } catch (Exception e) {
+            throw new TranslationException("Translation failed");
+        }
+    }
+
+    @Override
+    public boolean allowMultiLines() {
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- allow entering a DeepL API key in the UI
- add DeepL translator implementation using OkHttp
- show/hide API panes depending on the selected service and display translation errors in the interface

## Testing
- `mvn package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68583aa84a88832eab23879d67762392